### PR TITLE
Fix 5d8995e: Crash when extending a deleted train route

### DIFF
--- a/main.nut
+++ b/main.nut
@@ -3181,8 +3181,8 @@ class HogeAI extends AIController {
 		local sources = srcStationGroup.GetSources(route.cargo);
 		foreach(src in sources) { //TODO: 複数cargo
 			local location = src.stationGroup.GetLocation();
+			if(location == null) continue;
 			srcLocations.push(location);
-			//if(location == null) continue;
 			x += AIMap.GetTileX(location);
 			y += AIMap.GetTileY(location);
 			srcCruiseDays += src.days;


### PR DESCRIPTION
![Unnamed, 2063-12-15](https://github.com/user-attachments/assets/bec6863d-d58d-492d-91e0-717969bd42c0)

Hi. Unsure if you're willing to accept pull requests, but here's one crash I was able to fix.

I noticed there was a comment around there which is disabling code, so perhaps you were already aware of it.
Enabling the code in that line does not fix it fully, there would be one other crash later on which is caused due to pushing a `null` `location` to `srcLocations` array. Moving the now enabled line to before the push appears to solve the issue.