### PR TITLE
Fix: The index 'BuildDepot' does not exist

### DIFF
--- a/route.nut
+++ b/route.nut
@@ -2021,7 +2021,9 @@ class CommonRoute extends Route {
 			if(depot != null) {
 				return true;
 			}
-			path = path.GetParent();
+			if (path.GetParent() != null) {
+				path = path.GetParent();
+			}
 		}
 		depot = path.BuildDepot(GetVehicleType());
 		if(srcHgStation instanceof CanalStation || srcHgStation instanceof WaterStation) {


### PR DESCRIPTION
This is an attempt fix for the issue reported in https://www.tt-forums.net/viewtopic.php?p=1277652#p1277652

AAAHogEx is attempting to build a ship depot, but there's a rare occasion where `path` does not contain a parent node.

I didn't investigate the pathfinder side, so this may be an incorrect fix, but it at least prevents AAAHogEx from crashing.